### PR TITLE
Docker compatibility and README clarification

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,7 @@ docker-compose build .
 #### Starting the cluster
 Given that the RPM is installed at runtime, you need to download Vertica community edition at [http://my.vertica.com](http://my.vertica.com), and store it somewhere. You just need to provide it as an env variable.
 ```
-VERTICA_RPM_PATH=~/Downloads/vertica-8.0.0-0.x86_64.RHEL6.rpm \
-docker-compose up
+VERTICA_RPM_PATH=~/Downloads/vertica-8.0.0-0.x86_64.RHEL6.rpm docker-compose up
 ```
 
 #### Killing the container in a clean way

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     environment:
       NODE_TYPE: "master"
       CLUSTER_NODES: "node_1,node_2,node_3"
-      WITH_VMART: false
+      WITH_VMART: 'false'
     depends_on:
       - node_2
       - node_3

--- a/verticad
+++ b/verticad
@@ -99,7 +99,7 @@ then
   echo "Vertica is started."
 
   # Installs the VMart test schema if this has been supplied as environment variable
-  if [ ${WITH_VMART} = true ]
+  if [ ${WITH_VMART} = 'true' ]
   then
     if ! su - dbadmin -c "${VERTICA_HOME}/bin/vsql -qt -c 'select schema_name from schemata'" | grep -q online_sales
     then 


### PR DESCRIPTION
on most up to date docker/docker-compose
docker-compose version 1.16.1, build 6d1ac21
Docker version 17.09.0-ce, build afdb6d4

```
      ERROR: The Compose file './docker-compose.yml' is invalid because:
      services.node_1.environment.WITH_VMART contains false, which is an invalid type, it should be a string, number, or a null
```

Docker prevent booleans in compose as they are interpreted as yaml boolean and create confusion
https://docs.docker.com/compose/compose-file/#environment
